### PR TITLE
Remove User-Agent header from SlackClient

### DIFF
--- a/src/helpers/slack.js
+++ b/src/helpers/slack.js
@@ -1,6 +1,9 @@
 class SlackClient {
     constructor(webclient) {
         this.slackClient = webclient;
+        
+        // Remove User-Agent Header since it causes a CORS error on Safari and Firefox
+        delete this.slackClient["axios"].defaults.headers["User-Agent"];
     }
 
     /**


### PR DESCRIPTION
For some reason the SlackClient includes the User-Agent header in requests, even though the API doesn't accept it. This causes a CORS error on Safari & Firefox, resulting in an unusable site.

Removing the User-Agent header fixes this issue.