### PR TITLE
Create MessageTable component, edit scheduled messages

### DIFF
--- a/src/components/messageTable/messageTable.js
+++ b/src/components/messageTable/messageTable.js
@@ -1,0 +1,78 @@
+import { useContext, useRef, useState } from 'react';
+import AppContext from '../../AppContext';
+
+function MessageTable(props) {
+    const {messages, onUpdateMessage, onDeleteMessage, showIdCol=false} = props;
+
+    const {workspace} = useContext(AppContext);
+    const [selectedMessageId, setSelectedMessageId] = useState('');
+    const selectedMessageTextArea = useRef(null);
+
+    const editMessage = (id) => {
+        setSelectedMessageId(id)
+    }
+
+    const resetTextArea = (text) => {
+        selectedMessageTextArea.current.value = text; 
+        setSelectedMessageId('');
+    }
+
+    const updateMessage = (oldMessageDetails) => {
+        const updatedText = selectedMessageTextArea.current.value;
+        onUpdateMessage(oldMessageDetails, updatedText);
+        setSelectedMessageId('')
+    }
+
+    const generateRow = (message) => {
+        const {
+            messageDetails: {channel, ts, text}, 
+            log_ts
+        } = message;
+
+        const selected = selectedMessageId===log_ts;
+
+        return (
+            <tr key={log_ts}>
+                {showIdCol && <td>{log_ts}</td>}
+                <td>#{workspace && workspace.channels[channel].name}</td>
+                <td>{ts}</td>
+                <td>
+                    <textarea 
+                        defaultValue={text} 
+                        readOnly={!selected} 
+                        ref={selected ? selectedMessageTextArea : null}
+                    />
+                </td>
+                <td>
+                    { selected ?
+                        <div>
+                            <button onClick={()=>{resetTextArea(text)}}>Cancel</button>
+                            <button onClick={()=>{updateMessage(message)}}>Update</button>
+                        </div>
+                        :
+                        <button onClick={()=>{editMessage(log_ts)}}>Edit</button>
+                    }
+                </td>
+                <td><button onClick={()=>{onDeleteMessage(message)}}>Delete</button></td>
+            </tr>
+        )
+    }
+
+    return (
+        <table>
+            <tbody>
+                <tr>
+                    {showIdCol && <th>Id</th>}
+                    <th>Channel</th>
+                    <th>Timestamp</th>
+                    <th>Text</th>
+                    <th>Edit</th>
+                    <th>Delete Message</th>
+                </tr>
+                {messages.map(message => generateRow(message)) }
+            </tbody>       
+        </table>
+    )
+}
+
+export default MessageTable;

--- a/src/helpers/slack.js
+++ b/src/helpers/slack.js
@@ -96,6 +96,21 @@ class SlackClient {
     }
 
     /**
+     * Update Scheduled Message
+     * There is no slack api to update a scheduled message. 
+     * Instead we must delete the old message a schedule a new one at the same timestamp.
+     * 
+     * @param {string} scheduled_message_id - id of the scheduled message
+     * @param {string} channel              - channel id of the message
+     * @param {string} updated_text         - updated text to send
+     * @param {string} post_at              - epoch timestamp to send the message at
+     */
+    async updateScheduledMessage(scheduled_message_id, channel, updated_text, post_at) {
+        await this.deleteScheduledMessage(scheduled_message_id, channel);
+        await this.scheduleMessage(updated_text, channel, post_at);
+    }
+
+    /**
      * Get Scheduled Messages
      * 
      * @returns a list of scheduled messages

--- a/src/views/editMessage.js
+++ b/src/views/editMessage.js
@@ -1,14 +1,12 @@
 import './scheduleMessage.css';
 
-import MessageInput from '../components/messageInput/messageInput'
-import { useContext, useEffect, useRef, useState } from 'react';
+import MessageTable from '../components/messageTable/messageTable';
+import { useContext, useEffect, useState } from 'react';
 import AppContext from '../AppContext';
 
 function EditMessage() {
-    const {slackClient, workspace, isLoading} = useContext(AppContext);
+    const {slackClient, isLoading} = useContext(AppContext);
     const [prevMessages, setPrevMessages] = useState([]);
-    const [selectedMessageId, setSelectedMessageId] = useState('');
-    const selectedMessageTextArea = useRef(null);
     
     useEffect(()=>{
         if (!isLoading) {loadPrevMessages()};
@@ -20,20 +18,9 @@ function EditMessage() {
         })
     }
 
-    const editMessage = (id) => {
-        setSelectedMessageId(id)
-    }
-
-    const resetTextArea = (text) => {
-        selectedMessageTextArea.current.value = text; 
-        setSelectedMessageId('');
-    }
-
-    const updateMessage = async (oldMessageDetails) => {
+    const updateMessage = async (oldMessageDetails, updatedText) => {
         const {messageDetails: {channel, ts}, log_ts } = oldMessageDetails;
-        const updatedText = selectedMessageTextArea.current.value;
         await slackClient.editMessage(channel, ts, updatedText, log_ts);
-        setSelectedMessageId('')
         loadPrevMessages();
     }
 
@@ -48,50 +35,11 @@ function EditMessage() {
             <h1>Edit message</h1>
             <p>Select a message below to edit or delete.</p>
             <h3>Previous Messages</h3>
-            <table>
-                <tbody>
-                <tr>
-                    <th>Channel</th>
-                    <th>Timestamp</th>
-                    <th>Text</th>
-                    <th>Edit</th>
-                    <th>Delete Message</th>
-                </tr>
-                {prevMessages.map(message => {
-                    const {
-                        messageDetails: {channel, ts, text}, 
-                        log_ts
-                    } = message;
-
-                    const selected = selectedMessageId===log_ts;
-
-                    return (
-                        <tr key={log_ts}>
-                            <td>#{workspace && workspace.channels[channel].name}</td>
-                            <td>{ts}</td>
-                            <td>
-                                <textarea 
-                                    defaultValue={text} 
-                                    readOnly={!selected} 
-                                    ref={selected ? selectedMessageTextArea : null}
-                                />
-                            </td>
-                            <td>
-                                { selected ?
-                                    <div>
-                                        <button onClick={()=>{resetTextArea(text)}}>Cancel</button>
-                                        <button onClick={()=>{updateMessage(message)}}>Update</button>
-                                    </div>
-                                    :
-                                    <button onClick={()=>{editMessage(log_ts)}}>Edit</button>
-                                }
-                            </td>
-                            <td><button onClick={()=>{deleteMessage(message)}}>Delete</button></td>
-                        </tr>
-                    )
-                })}        
-                </tbody>       
-            </table>
+            <MessageTable 
+                messages={prevMessages}
+                onUpdateMessage={updateMessage}
+                onDeleteMessage={deleteMessage}
+            />
             {/* <h3>Manual Edit</h3>
             <p>If the message you want to edit is missing from the list above, you can also manually enter the message below.</p>
             <p><em>Note: You can only edit messages sent by the bot</em></p>


### PR DESCRIPTION
# Summary
- Create a MessageTable component that is used by both editMessage and scheduleMessage
Before, the /scheduleMessage and /editMessage pages both had separate tables that looked identical. Now, I've consolidated that logic down into one shared messageTable component.

- Add ability to edit scheduled messages
There's no api to "edit" a scheduled message. So this deletes the original message and schedules a new one with the updated text

# Test Plan
- Schedule messages and attempt to edit and delete them
- Edit and delete messages present on the /editMessage page

# Issues
Closes #4 
Closes #5 
