### PR TITLE
Refactor `slackClient` into single instance

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,22 +8,21 @@ import {useEffect, useState} from 'react';
 import NavBar from './components/navbar/navbar';
 import AppContext from './AppContext';
 import TokenInput from './components/tokenInput/tokenInput';
-import SlackClient from './helpers/slack';
+import slackClient from './helpers/slack';
+
 import SendMessage from './views/sendMessage';
 import Home from './views/home';
 import ScheduleMessage from './views/scheduleMessage';
 import EditMessage from './views/editMessage';
 
-const { WebClient } = require('@slack/web-api');
 
 function App() {
   const [token, setToken] = useState(localStorage['slackToken']);
   const [isLoading, setIsLoading] = useState(true);
-  const [slackClient, setSlackClient] = useState();
-  const [workspace, setWorkspace] = useState(); 
+  const [workspace, setWorkspace] = useState();
   const history = useHistory();
   const location = useLocation();
-  
+
   useEffect(() => {
     if (token) {
       // Save Slack token to local storage for future use
@@ -49,12 +48,10 @@ function App() {
   // If token is invalid, an alert will be shown
   const login = async () => {
     try {
-      // Create WebClient to interface with Slack API
-      const slackClient = new SlackClient(new WebClient(token)); 
-      await slackClient.init()
+      // Initialize Slack client with the token
+      await slackClient.init(token)
 
       // Update the states
-      setSlackClient(slackClient)
       setWorkspace(await slackClient.loadWorkspace());
       setIsLoading(false);
 
@@ -77,7 +74,7 @@ function App() {
 
   return (
     <div className="App">
-      <AppContext.Provider value={{slackClient, workspace, isLoading}}>
+      <AppContext.Provider value={{ workspace, isLoading }}>
         <NavBar onLogout={logout}/>
         <div className="content">
           <Route exact path="/" component={Home} />

--- a/src/helpers/slack.js
+++ b/src/helpers/slack.js
@@ -1,24 +1,30 @@
-class SlackClient {
-    constructor(webclient) {
-        this.slackClient = webclient;
-        
-        // Remove User-Agent Header since it causes a CORS error on Safari and Firefox
-        delete this.slackClient["axios"].defaults.headers["User-Agent"];
-    }
+import { WebClient } from "@slack/web-api";
 
+class SlackClient {
     /**
      * Initializer
      * This function must be called after constructing a new object.
      *
      * Afterwards, the following attributes are loaded on the SlackClient
+     *  slackClient - the Slack WebClient used to communicate with the Web API
      *  userId      - Bot's ID, used to send DMs to the Bot's channel.
      *  logChannel  - Channel ID for the bot's log 
      */
-    async init() {
+    async init(token) {
+        // Create WebClient to interface with Slack API
+        this.slackClient = new WebClient(token);
+
+        // Remove User-Agent Header since it causes a CORS error on Safari and Firefox
+        delete this.slackClient["axios"].defaults.headers["User-Agent"];
+
         const botInfo = await this.validateToken();
         this.userId = botInfo.user_id;
 
         this.logChannel = await this._getLogChannel();
+    }
+
+    logout() {
+        delete this.slackClient;
     }
 
     /**
@@ -269,4 +275,5 @@ class SlackClient {
     }
 }
 
-export default SlackClient;
+const slackClient = new SlackClient();
+export default slackClient;

--- a/src/views/editMessage.js
+++ b/src/views/editMessage.js
@@ -3,9 +3,10 @@ import './scheduleMessage.css';
 import MessageTable from '../components/messageTable/messageTable';
 import { useContext, useEffect, useState } from 'react';
 import AppContext from '../AppContext';
+import slackClient from '../helpers/slack';
 
 function EditMessage() {
-    const {slackClient, isLoading} = useContext(AppContext);
+    const { isLoading } = useContext(AppContext);
     const [prevMessages, setPrevMessages] = useState([]);
     
     useEffect(()=>{

--- a/src/views/scheduleMessage.js
+++ b/src/views/scheduleMessage.js
@@ -4,9 +4,11 @@ import MessageInput from '../components/messageInput/messageInput'
 import { useContext, useEffect, useRef, useState } from 'react';
 import AppContext from '../AppContext';
 import MessageTable from '../components/messageTable/messageTable';
+import slackClient from '../helpers/slack';
+
 
 function ScheduleMessage() {
-    const {slackClient, isLoading} = useContext(AppContext);
+    const { isLoading } = useContext(AppContext);
     const [scheduledMessages, setScheduledMessages] = useState([]);
     const timeInput = useRef(null)
     

--- a/src/views/sendMessage.js
+++ b/src/views/sendMessage.js
@@ -1,10 +1,9 @@
+import React from "react";
 import MessageInput from '../components/messageInput/messageInput'
-import AppContext from '../AppContext';
-import {useContext} from 'react';
+
+import slackClient from '../helpers/slack';
 
 function SendMessage() {
-    const { slackClient } = useContext(AppContext);
-
     const sendMessage = (message, channel) => {
         slackClient.postMessage(message, channel);
     }


### PR DESCRIPTION
The `SlackClient` instance is shared among all components that interact
with the API. There was little benefit from using dependency injection,
so the `slackClient` module was changed to export a single instance.
This also reduces any possible confusion from considering the client as
a state since object mutations would not necessarily cause a re-render.