### PR TITLE
Sort scheduled messages, add datetime column to messageTable

### DIFF
--- a/src/components/messageTable/messageTable.js
+++ b/src/components/messageTable/messageTable.js
@@ -35,6 +35,7 @@ function MessageTable(props) {
             <tr key={log_ts}>
                 {showIdCol && <td>{log_ts}</td>}
                 <td>#{workspace && workspace.channels[channel].name}</td>
+                <td>{new Date(ts*1000).toLocaleString()}</td>
                 <td>{ts}</td>
                 <td>
                     <textarea 
@@ -64,6 +65,7 @@ function MessageTable(props) {
                 <tr>
                     {showIdCol && <th>Id</th>}
                     <th>Channel</th>
+                    <th>Datetime</th>
                     <th>Timestamp</th>
                     <th>Text</th>
                     <th>Edit</th>

--- a/src/helpers/slack.js
+++ b/src/helpers/slack.js
@@ -122,11 +122,16 @@ class SlackClient {
     /**
      * Get Scheduled Messages
      * 
-     * @returns a list of scheduled messages
+     * @returns a list of scheduled messages sorted by timestamp
      */
     async getScheduledMessages() {
         const resp = await this.slackClient.chat.scheduledMessages.list();
-        return resp.scheduled_messages;
+
+        // Sort the scheduled messages by post_at time
+        // Earliest messages will appear first
+        const scheduledMessages = resp.scheduled_messages.sort((m1, m2) => m1.post_at-m2.post_at);
+
+        return scheduledMessages;
     }
 
     /**


### PR DESCRIPTION
- Scheduled messages are now sorted by timestamp in the table (soonest to latest)
- A datetime column has been added to messageTime, displaying the date and time of the timestamp

![image](https://user-images.githubusercontent.com/29494270/129513012-2a887a34-d673-44e0-99b4-7d0258a25427.png)
